### PR TITLE
Add check if message is null before sending

### DIFF
--- a/Chernobyl Relay Chat/CRCClient.cs
+++ b/Chernobyl Relay Chat/CRCClient.cs
@@ -116,9 +116,11 @@ namespace Chernobyl_Relay_Chat
 
         public static void Send(string message)
         {
-            client.SendMessage(SendType.Message, CRCOptions.ChannelProxy(), message);
-            CRCDisplay.OnOwnChannelMessage(CRCOptions.Name, message);
-            CRCGame.OnChannelMessage(CRCOptions.Name, CRCOptions.GetFaction(), message);
+            if (message != null) { 
+                client.SendMessage(SendType.Message, CRCOptions.ChannelProxy(), message);
+                CRCDisplay.OnOwnChannelMessage(CRCOptions.Name, message);
+                CRCGame.OnChannelMessage(CRCOptions.Name, CRCOptions.GetFaction(), message);
+            }
         }
 
         public static void SendDeath(string message)


### PR DESCRIPTION
In the CRC client a warning sign would repeatedly show if a user sent a message without typing anything. Since this may be annoying to ~~any~~ some users, I've added an 'if' check to see if a message should actually be sent.